### PR TITLE
feat: add data_collection_rule + data_collection_endpoint data modules AB#7781

### DIFF
--- a/data_collection_endpoint/main.tf
+++ b/data_collection_endpoint/main.tf
@@ -14,7 +14,7 @@ provider "azurerm" {
   features {}
 }
 
-data "azurerm_monitor_data_collection_endpoint" "this" {
+data "azurerm_monitor_data_collection_endpoint" "data_collection_endpoint" {
   name                = var.name
   resource_group_name = var.resource_group_name
 }

--- a/data_collection_endpoint/main.tf
+++ b/data_collection_endpoint/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = "~> 1.12"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.117"
+    }
+  }
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_monitor_data_collection_endpoint" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+}

--- a/data_collection_endpoint/outputs.tf
+++ b/data_collection_endpoint/outputs.tf
@@ -1,7 +1,7 @@
 output "id" {
-  value = data.azurerm_monitor_data_collection_endpoint.this.id
+  value = data.azurerm_monitor_data_collection_endpoint.data_collection_endpoint.id
 }
 
 output "logs_ingestion_endpoint" {
-  value = data.azurerm_monitor_data_collection_endpoint.this.logs_ingestion_endpoint
+  value = data.azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint
 }

--- a/data_collection_endpoint/outputs.tf
+++ b/data_collection_endpoint/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = data.azurerm_monitor_data_collection_endpoint.this.id
+}
+
+output "logs_ingestion_endpoint" {
+  value = data.azurerm_monitor_data_collection_endpoint.this.logs_ingestion_endpoint
+}

--- a/data_collection_endpoint/variables.tf
+++ b/data_collection_endpoint/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type        = string
+  description = "The name of the Data Collection Endpoint to retrieve."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The name of the resource group in which the Data Collection Endpoint resides."
+}

--- a/data_collection_rule/main.tf
+++ b/data_collection_rule/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = "~> 1.12"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.117"
+    }
+  }
+  backend "azurerm" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_monitor_data_collection_rule" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+}

--- a/data_collection_rule/main.tf
+++ b/data_collection_rule/main.tf
@@ -14,7 +14,7 @@ provider "azurerm" {
   features {}
 }
 
-data "azurerm_monitor_data_collection_rule" "this" {
+data "azurerm_monitor_data_collection_rule" "data_collection_rule" {
   name                = var.name
   resource_group_name = var.resource_group_name
 }

--- a/data_collection_rule/outputs.tf
+++ b/data_collection_rule/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = data.azurerm_monitor_data_collection_rule.this.id
+}
+
+output "immutable_id" {
+  value = data.azurerm_monitor_data_collection_rule.this.immutable_id
+}

--- a/data_collection_rule/outputs.tf
+++ b/data_collection_rule/outputs.tf
@@ -1,7 +1,7 @@
 output "id" {
-  value = data.azurerm_monitor_data_collection_rule.this.id
+  value = data.azurerm_monitor_data_collection_rule.data_collection_rule.id
 }
 
 output "immutable_id" {
-  value = data.azurerm_monitor_data_collection_rule.this.immutable_id
+  value = data.azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id
 }

--- a/data_collection_rule/variables.tf
+++ b/data_collection_rule/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type        = string
+  description = "The name of the Data Collection Rule to retrieve."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The name of the resource group in which the Data Collection Rule resides."
+}


### PR DESCRIPTION
Adds two data-only Terraform modules:

- `data_collection_rule` (`azurerm_monitor_data_collection_rule`) — outputs `id` and `immutable_id`
- `data_collection_endpoint` (`azurerm_monitor_data_collection_endpoint`) — outputs `id` and `logs_ingestion_endpoint`

Both follow the existing `application_insights` module structure (same `required_version`, `azurerm ~> 3.117` provider, `backend "azurerm" {}`).

Needed for the service-ticket DCR cross-repo wiring of US 7780. After merge a new version tag must be released so the hub `terragrunt_data_module_version` can point to it.

AB#7781