### PR TITLE
feat: expose Application Insights connection_string output AB#7636

### DIFF
--- a/application_insights/outputs.tf
+++ b/application_insights/outputs.tf
@@ -2,6 +2,10 @@ output "instrumentation_key" {
   value = data.azurerm_application_insights.application_insights.instrumentation_key
 }
 
+output "connection_string" {
+  value = data.azurerm_application_insights.application_insights.connection_string
+}
+
 output "id" {
   value = data.azurerm_application_insights.application_insights.id
 }


### PR DESCRIPTION
## Wat
Voegt een `connection_string` output toe aan het `application_insights` data-module.

## Waarom
Consumers (o.a. de nieuwe service-tickets incoming-handler Function App, AB#7636) kunnen hiermee `APPLICATIONINSIGHTS_CONNECTION_STRING` bedraden i.p.v. de deprecated `APPINSIGHTS_INSTRUMENTATIONKEY`. De connection string is toekomstbestendig (regionale ingestion) en wordt door de Functions worker-SDK automatisch opgepikt.

## Impact
Pure additieve wijziging — net-diff t.o.v. v4.2.5 is enkel deze output. Geen breaking changes voor bestaande consumers. Na merge een `v4.2.6` tag releasen; de incoming-handler env.hcl's verwijzen daar al naar.

`terraform validate` ✓