### PR TITLE
fix: mark application_insights connection_string output as sensitive (AB#7844)

### DIFF
--- a/application_insights/outputs.tf
+++ b/application_insights/outputs.tf
@@ -3,7 +3,8 @@ output "instrumentation_key" {
 }
 
 output "connection_string" {
-  value = data.azurerm_application_insights.application_insights.connection_string
+  value     = data.azurerm_application_insights.application_insights.connection_string
+  sensitive = true
 }
 
 output "id" {


### PR DESCRIPTION
The `application_insights` data module returns `connection_string` from an output without `sensitive = true`. Current Terraform/azurerm reject this ("Output refers to sensitive values"), blocking any **fresh** apply of a unit that uses this module (surfaced deploying the new observability/log-receiver workload, AB#7844). Existing workloads with prior state didn't hit it.

One-line fix: mark the output `sensitive = true`. Backward-compatible. Released as tag **v4.2.8** for immediate consumption.